### PR TITLE
Changed Mapper to directly implement FieldDefinitionFormMapperInterface and FieldValueFormMapperInterface interfaces

### DIFF
--- a/bundle/Core/FieldType/Mapper.php
+++ b/bundle/Core/FieldType/Mapper.php
@@ -10,9 +10,11 @@
 
 namespace IntProg\EnhancedRelationListBundle\Core\FieldType;
 
+use eZ\Publish\API\Repository\ContentTypeService;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\Mapper\AbstractRelationFormMapper;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use IntProg\EnhancedRelationListBundle\Form\Type\EnhancedRelationListFieldDefinitionAttributesType;
 use IntProg\EnhancedRelationListBundle\Form\Type\EnhancedRelationListFieldDefinitionGroupsType;
 use IntProg\EnhancedRelationListBundle\Form\Type\EnhancedRelationListType;
@@ -29,8 +31,21 @@ use Symfony\Component\Form\FormInterface;
  * @author    Konrad, Steve <s.konrad@wingmail.net>
  * @copyright 2018 Intense Programming
  */
-class Mapper extends AbstractRelationFormMapper
+class Mapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
+    /** @var ContentTypeService Used to fetch list of available content types */
+    private $contentTypeService;
+
+    /**
+     * Mapper constructor.
+     *
+     * @param ContentTypeService $contentTypeService
+     */
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
     /**
      * Adds the form fields for the field definition edit.
      *
@@ -173,4 +188,22 @@ class Mapper extends AbstractRelationFormMapper
                     ->getForm()
             );
     }
+
+   /**
+     * Fill a hash with all content types and their identifiers.
+     *
+     * @return array
+     */
+   private function getContentTypesHash(): array
+   {
+       $contentTypeHash = [];
+       foreach ($this->contentTypeService->loadContentTypeGroups() as $contentTypeGroup) {
+           foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
+               $contentTypeHash[$contentType->getName()] = $contentType->identifier;
+           }
+       }
+       ksort($contentTypeHash);
+
+       return $contentTypeHash;
+   }
 }

--- a/tests/Core/FieldType/MapperTest.php
+++ b/tests/Core/FieldType/MapperTest.php
@@ -31,9 +31,7 @@ class MapperTest extends TestCase
             $this->createMock(ContentTypeGroup::class)
         ]);
         $contentTypeService->expects($this->once())->method('loadContentTypes')->willReturn([
-            $this->createContentTypeMock('foo', 'Foo'),
-            $this->createContentTypeMock('bar', 'Bar'),
-            $this->createContentTypeMock('baz', 'Baz'),
+            $this->createMock(ContentType::class)
         ]);
 
         $fieldForm = $this->createMock(Form::class);
@@ -141,22 +139,5 @@ class MapperTest extends TestCase
                 ],
             ],
         ]);
-    }
-
-    /**
-     * Returns mock of the ContentType.
-     *
-     * @param string $identifier
-     * @param string $name
-     *
-     * @return ContentType
-     */
-    private function createContentTypeMock(string $identifier, string $name): ContentType
-    {
-        $contentType = $this->createMock(ContentType::class);
-        $contentType->expects($this->once())->method('getName')->willReturn($name);
-        $contentType->expects($this->once())->method('__get')->with('identifier')->willReturn($identifier);
-
-        return $contentType;
     }
 }

--- a/tests/Core/FieldType/MapperTest.php
+++ b/tests/Core/FieldType/MapperTest.php
@@ -10,6 +10,8 @@
 
 namespace IntProg\EnhancedRelationListBundle\Core\FieldType;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\Core\Repository\ContentTypeService;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
@@ -25,7 +27,14 @@ class MapperTest extends TestCase
     public function testMapFieldDefinitionForm()
     {
         $contentTypeService = $this->createMock(ContentTypeService::class);
-        $contentTypeService->expects($this->once())->method('loadContentTypeGroups')->willReturn([]);
+        $contentTypeService->expects($this->once())->method('loadContentTypeGroups')->willReturn([
+            $this->createMock(ContentTypeGroup::class)
+        ]);
+        $contentTypeService->expects($this->once())->method('loadContentTypes')->willReturn([
+            $this->createContentTypeMock('foo', 'Foo'),
+            $this->createContentTypeMock('bar', 'Bar'),
+            $this->createContentTypeMock('baz', 'Baz'),
+        ]);
 
         $fieldForm = $this->createMock(Form::class);
         $fieldForm->expects($this->exactly(9))->method('add')->willReturn($fieldForm);
@@ -132,5 +141,22 @@ class MapperTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * Returns mock of the ContentType.
+     *
+     * @param string $identifier
+     * @param string $name
+     *
+     * @return ContentType
+     */
+    private function createContentTypeMock(string $identifier, string $name): ContentType
+    {
+        $contentType = $this->createMock(ContentType::class);
+        $contentType->expects($this->once())->method('getName')->willReturn($name);
+        $contentType->expects($this->once())->method('__get')->with('identifier')->willReturn($identifier);
+
+        return $contentType;
     }
 }


### PR DESCRIPTION
Changed `\IntProg\EnhancedRelationListBundle\Core\FieldType\Mapper` to directly implement FieldDefinitionFormMapperInterface and FieldValueFormMapperInterface interfaces instead of extend  `\EzSystems\RepositoryForms\FieldType\Mapper\AbstractRelationFormMapper` which  shouldn't be used outside `repository-forms` 😉  

#### TODO
- [X] Implement feature/bugfix
- [X] Implement/adjust unit tests
- [ ] Squash commits before merge